### PR TITLE
Add option to download file as byte-array

### DIFF
--- a/src/cybozu_http/kintone/api/file.clj
+++ b/src/cybozu_http/kintone/api/file.clj
@@ -22,6 +22,7 @@
       (c/parse-string true)
       :fileKey))
 
-(defn download* [auth file-key & {:as opts}]
-  (let [params (bare/build-params :get {:fileKey file-key})]
+(defn download* [auth file-key & {:keys [as-byte-array?] :as opts}]
+  (let [params (cond-> (bare/build-params :get {:fileKey file-key})
+                 as-byte-array? (assoc :as :byte-array))]
     (bare/api-call auth :get "/file.json" params)))

--- a/test/cybozu_http/kintone/api/file_test.clj
+++ b/test/cybozu_http/kintone/api/file_test.clj
@@ -10,16 +10,25 @@
 (reset-meta! *ns* {})
 (t/use-fixtures :once (h/wrap-setup db))
 
+(defn- byte-array? [x]
+  (= (type x)
+     (Class/forName "[B")))
+
 (t/deftest upload-download-test
-  (t/testing "file upload test"
-    (let [{:keys [auth app-id]} @db
-          file (io/file (io/resource "upload-test-file.org"))
-          upload-res (f/upload auth file)
-          {id :id} (->> (assoc-in h/record ["attachment_file" :value 0 :fileKey] upload-res)
-                        (hash-map :record)
-                        (r/post auth app-id))
-          res (r/get auth app-id id)
-          download-res (f/download* auth (get-in res [:attachment_file :value 0 :fileKey]))]
+  (let [{:keys [auth app-id]} @db
+        file (io/file (io/resource "upload-test-file.org"))
+        upload-res (f/upload auth file)
+        {id :id} (->> (assoc-in h/record ["attachment_file" :value 0 :fileKey] upload-res)
+                      (hash-map :record)
+                      (r/post auth app-id))
+        res (r/get auth app-id id)
+        file-key (get-in res [:attachment_file :value 0 :fileKey])
+        download-res (f/download* auth file-key)]
+    (t/testing "file upload test"
       (t/is (string? upload-res))
       (t/is (string? (:body download-res)))
-      (t/is (= (:body download-res) (slurp file))))))
+      (t/is (= (:body download-res) (slurp file))))
+
+    (t/testing "download as byte-array test"
+      (let [download-res (f/download* auth file-key :as-byte-array? true)]
+        (t/is (byte-array? (:body download-res)))))))


### PR DESCRIPTION
Add `as-byte-array?` option to `cybozu-http.kintone.api.file/download*` for binary attachment files